### PR TITLE
Handle digital / nonshippable products

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Solidus + EasyPost
 
-[![CircleCI](https://circleci.com/gh/solidusio-contrib/solidus_easypost.svg?style=svg)](https://circleci.com/gh/solidusio-contrib/solidus_easypost)
+[![CircleCI](https://circleci.com/gh/boomerdigital/solidus_easypost.svg?style=svg)](https://circleci.com/gh/boomerdigital/solidus_easypost)
 
 This is an extension to integrate Easy Post into Spree. Due to how it works, you will not be able to use any other extension than this for shipping methods. Your own shipping methods will not work, either. But the good thing is that you won't have to worry about that, because Easy Post handles it all for you.
 
@@ -29,6 +29,12 @@ To enable DDP, place this in the file `config/initializers/easy_post.rb`:
   Spree::Easypost::Config.ddp_enabled = true
 ```
 
+We also have the below configurations available.
+```ruby
+Spree::Easypost::Config.api_enabled = true # default
+Spree::Easypost::Config.address_verification_enabled = false # default
+Spree::Easypost::Config.verify_strict_enabled = false # default
+```
 
 ## Usage
 

--- a/app/decorators/models/solidus_easypost/spree/stock/estimator_decorator.rb
+++ b/app/decorators/models/solidus_easypost/spree/stock/estimator_decorator.rb
@@ -6,7 +6,7 @@ module SolidusEasypost
       module EstimatorDecorator
 
         def shipping_rates(package, frontend_only = true)
-          if ::Spree::Easypost::Config.api_enabled
+          if ::Spree::Easypost::Config.api_enabled && !package.stock_location.is_digital?
             shipment = package.easypost_shipment
             rates = shipment.rates.sort_by { |r| r.rate.to_i }
 

--- a/app/overrides/add_is_digital_field.rb
+++ b/app/overrides/add_is_digital_field.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Deface::Override.new(
+  virtual_path: 'spree/admin/stock_locations/_form',
+  name: 'add is_digital field',
+  insert_bottom: '[data-hook="admin_stock_locations_form_fields"]',
+  partial: 'spree/admin/stock_locations/is_digital_field'
+)

--- a/app/views/spree/admin/stock_locations/_is_digital_field.html.erb
+++ b/app/views/spree/admin/stock_locations/_is_digital_field.html.erb
@@ -1,0 +1,7 @@
+<%= f.field_container :is_digital do %>
+  <label>
+    <%= f.check_box :is_digital %>
+    <%= Spree::StockLocation.human_attribute_name :is_digital %>
+    <%= f.field_hint :is_digital %>
+  </label>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,5 @@
+en:
+  spree:
+    hints:
+      spree/stock_location:
+        is_digital: For digital or non shippable products

--- a/db/migrate/20200413151950_add_is_digital_to_stock_location.rb
+++ b/db/migrate/20200413151950_add_is_digital_to_stock_location.rb
@@ -1,0 +1,5 @@
+class AddIsDigitalToStockLocation < SolidusSupport::Migration[4.2]
+  def change
+    add_column :spree_stock_locations, :is_digital, :boolean, default: false
+  end
+end

--- a/spec/cassettes/Spree_Address/_easypost_address/verifies_the_address_inputted.yml
+++ b/spec/cassettes/Spree_Address/_easypost_address/verifies_the_address_inputted.yml
@@ -33,7 +33,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ep-Request-Uuid:
-      - 7a43cb4a5e8a2ebdfebde29d00071de3
+      - a9ab08c65e961892e5e04c1f0012c889
       Cache-Control:
       - no-cache, no-store, must-revalidate, private
       Pragma:
@@ -41,28 +41,31 @@ http_interactions:
       Expires:
       - '0'
       Location:
-      - "/api/v2/addresses/adr_28ca59f180b444a883339a90e7801501"
+      - "/api/v2/addresses/adr_0d826fb10d524283b627cb6d4711746b"
       Content-Type:
       - application/json; charset=utf-8
       X-Runtime:
-      - '0.077062'
+      - '0.131514'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb8sj
+      - bigweb7sj
       X-Version-Label:
-      - easypost-202004040128-16fe9181c9-master
+      - easypost-202004141838-9f18a0b30e-master
       X-Backend:
       - easypost
+      X-Canary:
+      - direct
       X-Proxied:
-      - extlb1sj 4515783a4a
-      - intlb2sj 1cda4c0014
+      - extlb1wdc 5834894b53
+      - intlb1sj 5834894b53
+      - intlb2wdc 5834894b53
       Strict-Transport-Security:
       - max-age=15768000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"adr_28ca59f180b444a883339a90e7801501","object":"Address","created_at":"2020-04-05T19:17:17Z","updated_at":"2020-04-05T19:17:17Z","name":"JOHN
+      string: '{"id":"adr_0d826fb10d524283b627cb6d4711746b","object":"Address","created_at":"2020-04-14T20:09:54Z","updated_at":"2020-04-14T20:09:54Z","name":"JOHN
         DOE","company":"COMPANY","street1":"215 N 7TH AVE","street2":"","city":"MANVILLE","state":"NJ","zip":"08835-1215","country":"US","phone":"5555550199","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"delivery":{"success":true,"errors":[],"details":{"latitude":40.54849,"longitude":-74.59299,"time_zone":"America/New_York"}}}}'
     http_version: null
-  recorded_at: Sun, 05 Apr 2020 19:17:17 GMT
+  recorded_at: Tue, 14 Apr 2020 20:09:55 GMT
 recorded_with: VCR 5.1.0

--- a/spec/models/spree/address_spec.rb
+++ b/spec/models/spree/address_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Spree::Address, :vcr do
 
     it 'verifies the address inputted' do
       Spree::Easypost::Config.address_verification_enabled = true
+      Spree::Easypost::Config.verify_strict_enabled = false
 
       expect(subject['verifications']['delivery']['success']).to be_truthy
     end

--- a/spec/models/spree/stock/estimator_spec.rb
+++ b/spec/models/spree/stock/estimator_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Spree::Stock::Estimator, :vcr do
 
     context 'no rates are found' do
       let(:package) do
-        instance_double(Spree::Stock::Package, easypost_shipment: fake_shipment)
+        instance_double(Spree::Stock::Package, easypost_shipment: fake_shipment, stock_location: Spree::StockLocation.new)
       end
 
       let(:fake_shipment) do

--- a/spec/support/easypost.rb
+++ b/spec/support/easypost.rb
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 
 EasyPost.api_key = 'EZTKa6a3653e4e3f4b2883013f4c20e1f28b6camRFWNI0aRqQQqDnQKkg'
+Spree::Easypost::Config.api_enabled = true
+Spree::Easypost::Config.address_verification_enabled = false
+Spree::Easypost::Config.verify_strict_enabled = false

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -7,5 +7,5 @@ VCR.configure do |config|
   config.cassette_library_dir = 'spec/cassettes'
   config.hook_into :webmock
   config.configure_rspec_metadata!
-  config.default_cassette_options = { record: :none }
+  config.default_cassette_options = { record: :once, :match_requests_on => [:method] }
 end


### PR DESCRIPTION
Digital Products:
1. Create a stock location only for digital products: Check is digital to true.
2. Shipping Category “Digital Products” or whatever you would like
3. Shipping Method for digital products: Set stock location to the is digital enabled one, shipping category to digital products, set flat rate of 0
4. Assign shipping category to products that are digital products
5. Adjust stock on digital products to only have backorderable checked on the digital product stock location. 0 on hand for all. 
6. Adjust stock on all non digital products to have backorderable set to false.